### PR TITLE
perf: inline hot-path in add() and drop redundant checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ harness = false
 name = "ddsketch_bench"
 harness = false
 
+[[bench]]
+name = "insert_compare"
+harness = false
+
 [[example]]
 name = "readme_example"
 

--- a/benches/insert_compare.rs
+++ b/benches/insert_compare.rs
@@ -1,0 +1,37 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ddsketchy::DDSketch as Ours;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use sketches_ddsketch::{Config, DDSketch as Ref};
+
+fn bench_insert(c: &mut Criterion) {
+    let mut group = c.benchmark_group("insert");
+
+    for &size in &[1_000usize, 10_000, 100_000] {
+        let mut rng = StdRng::seed_from_u64(42);
+        let values: Vec<f64> = (0..size).map(|_| rng.random::<f64>() * 1000.0).collect();
+
+        group.bench_with_input(BenchmarkId::new("ddsketchy", size), &size, |b, &_n| {
+            b.iter(|| {
+                let mut s = Ours::new(0.01).expect("valid alpha");
+                for &v in &values {
+                    s.add(v);
+                }
+                std::hint::black_box(s);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("reference", size), &size, |b, &_n| {
+            b.iter(|| {
+                let mut s = Ref::new(Config::defaults());
+                for &v in &values {
+                    s.add(v);
+                }
+                std::hint::black_box(s);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_insert);
+criterion_main!(benches);

--- a/src/ddsketchy.rs
+++ b/src/ddsketchy.rs
@@ -178,29 +178,27 @@ impl DDSketch {
     /// Add a value to the sketch
     #[inline]
     pub fn add(&mut self, value: f64) {
-        // Skip infinite/NaN values immediately
         if !value.is_finite() {
             return;
         }
 
-        // DataDog semantics: extremely small magnitudes are mapped to the zero bucket.
-        // Values below MinIndexableValue go to zero bucket.
-        if value == 0.0 || value.abs() < self.min_indexable_value {
-            self.zero_count += 1;
-        } else if value > 0.0 {
-            // Positive value -> positive store
-            let key = self.key(value);
+        if value >= self.min_indexable_value {
+            let key = (value.ln() * self.inv_ln_gamma).ceil() as i32;
             self.positive_store.add(key);
-        } else {
-            // Negative value -> negative store with key(-value)
-            let key = self.key(-value);
+        } else if value <= -self.min_indexable_value {
+            let key = ((-value).ln() * self.inv_ln_gamma).ceil() as i32;
             self.negative_store.add(key);
+        } else {
+            self.zero_count += 1;
         }
 
-        // Update metadata
         self.sum += value;
-        self.min = self.min.min(value);
-        self.max = self.max.max(value);
+        if value < self.min {
+            self.min = value;
+        }
+        if value > self.max {
+            self.max = value;
+        }
     }
 
     /// Merge another sketch into this one
@@ -347,7 +345,7 @@ impl DDSketch {
     ///
     /// Returns 0.0 if the sketch is empty for backward compatibility.
     pub fn quantile(&self, q: f64) -> Result<f64, DDSketchError> {
-        if !q.is_finite() || !(0.0..=1.0).contains(&q) {
+        if !(0.0..=1.0).contains(&q) {
             return Err(DDSketchError::InvalidQuantile);
         }
 
@@ -388,7 +386,7 @@ impl DDSketch {
 
     /// Returns the value at the given quantile, with Option for empty handling
     pub fn quantile_opt(&self, q: f64) -> Result<Option<f64>, DDSketchError> {
-        if !q.is_finite() || !(0.0..=1.0).contains(&q) {
+        if !(0.0..=1.0).contains(&q) {
             return Err(DDSketchError::InvalidQuantile);
         }
         if self.count() == 0 {


### PR DESCRIPTION
## Summary

Five small optimizations on the insert and quantile hot paths, following a review against the `sketches-ddsketch` reference implementation.

### Changes

1. **Inline key computation in `DDSketch::add`**. Bypasses `mapping::value_to_key`'s redundant `.abs()` and `== 0.0` early-return since callers in the positive/negative branches already guarantee positive finite input. Directly casts `ceil() as i32` instead of i64-then-cast.

2. **Restructure `add()` branching** to match the reference's shape: `value >= min_indexable_value` → positive store, `value <= -min_indexable_value` → negative store, else zero bucket. Semantically equivalent to the previous `abs() < min_indexable_value || value == 0.0` test but uses a single comparison per side.

3. **Direct `<`/`>` for min/max updates** instead of `f64::min`/`f64::max`. Values are already guaranteed finite by the `is_finite()` guard at the top of `add()`, so the NaN-ordering semantics of `f64::min`/`max` are unnecessary overhead.

4. **Drop redundant `!q.is_finite()` check** in `quantile()` and `quantile_opt()`. `(0.0..=1.0).contains(&q)` already rejects NaN (NaN compares as neither in-range nor out) as well as ±infinity, so the prior `is_finite` guard was a redundant branch.

5. **Add `benches/insert_compare.rs`** — a small criterion harness comparing `DDSketch::add` against `sketches_ddsketch::DDSketch::add` at 1k / 10k / 100k values. Useful for catching insert-path regressions against the reference.

### No public API change

`mapping::value_to_key`, `value_to_key_i32`, and friends keep their current signatures. The optimization is a local hot-path inline, not a surface-level rewrite.

## Test plan

- [x] `cargo test --lib` — 62/62 pass
- [x] `cargo bench --bench insert_compare` — ddsketchy stays ahead of reference at all sizes
- [ ] Reviewer sanity check on the branch-shape equivalence (specifically: `value >= min_indexable || value <= -min_indexable || else zero` vs old `value == 0.0 || abs() < min_indexable`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)