### PR TITLE
docs: expand crate-level docs, doctests, and docs CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,9 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    env:
+      # Fail the build on broken intra-doc links or other rustdoc warnings.
+      RUSTDOCFLAGS: "-D warnings"
 
     steps:
     - uses: actions/checkout@v4
@@ -84,7 +87,7 @@ jobs:
       run: cargo test --doc --all-features
 
     - name: Build examples
-      run: cargo build --examples --verbose
+      run: cargo build --examples --verbose --features serde
 
     - name: Run all examples
       run: |

--- a/src/ddsketchy.rs
+++ b/src/ddsketchy.rs
@@ -89,7 +89,7 @@ where
 /// }
 /// let p99 = sketch.quantile(0.99).unwrap();
 /// // Result is within 1% relative error of 99.
-/// assert!((p99 - 99.0).abs() < 99.0 * 0.01);
+/// assert!((p99 - 99.0).abs() <= 99.0 * 0.01);
 /// ```
 ///
 /// # Serialization
@@ -98,7 +98,7 @@ where
 /// `serde::Serialize` and `serde::Deserialize`:
 ///
 /// ```toml
-/// ddsketchy = { version = "*", features = ["serde"] }
+/// ddsketchy = { version = "0.1", features = ["serde"] }
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -436,7 +436,7 @@ impl DDSketch {
     /// sketch.add(1.0);
     /// sketch.add(10.0);
     /// // min is reconstructed and therefore only approximate.
-    /// assert!((sketch.min() - 1.0).abs() < 1.0 * 0.01);
+    /// assert!((sketch.min() - 1.0).abs() <= 1.0 * 0.01);
     /// ```
     #[inline]
     pub fn min(&self) -> f64 {
@@ -458,7 +458,7 @@ impl DDSketch {
     /// let mut sketch = DDSketch::new(0.01).unwrap();
     /// sketch.add(1.0);
     /// sketch.add(10.0);
-    /// assert!((sketch.max() - 10.0).abs() < 10.0 * 0.01);
+    /// assert!((sketch.max() - 10.0).abs() <= 10.0 * 0.01);
     /// ```
     #[inline]
     pub fn max(&self) -> f64 {
@@ -511,7 +511,9 @@ impl DDSketch {
     ///     sketch.add(v as f64);
     /// }
     /// let median = sketch.quantile(0.5).unwrap();
-    /// assert!((median - 50.0).abs() < 50.0 * 0.01 + 0.5);
+    /// // q=0.5 returns the rank-50 value (50.0), not the continuous median (50.5),
+/// // so the relative-error bound is 50.0 * alpha.
+/// assert!((median - 50.0).abs() <= 50.0 * 0.01);
     /// ```
     pub fn quantile(&self, q: f64) -> Result<f64, DDSketchError> {
         if !(0.0..=1.0).contains(&q) {

--- a/src/ddsketchy.rs
+++ b/src/ddsketchy.rs
@@ -512,8 +512,8 @@ impl DDSketch {
     /// }
     /// let median = sketch.quantile(0.5).unwrap();
     /// // q=0.5 returns the rank-50 value (50.0), not the continuous median (50.5),
-/// // so the relative-error bound is 50.0 * alpha.
-/// assert!((median - 50.0).abs() <= 50.0 * 0.01);
+    /// // so the relative-error bound is 50.0 * alpha.
+    /// assert!((median - 50.0).abs() <= 50.0 * 0.01);
     /// ```
     pub fn quantile(&self, q: f64) -> Result<f64, DDSketchError> {
         if !(0.0..=1.0).contains(&q) {

--- a/src/ddsketchy.rs
+++ b/src/ddsketchy.rs
@@ -1,18 +1,24 @@
-//! A self-contained, correct, fast DDSketch implementation with internal tests.
-//! No external dependencies except `rand_distr` for internal tests.
+//! Core DDSketch implementation.
+//!
+//! This module defines the public [`DDSketch`] type, the [`DDSketchBuilder`]
+//! for customized construction, and the [`DDSketchError`] type returned by
+//! fallible operations.
 
 use crate::store::Store;
 
-/// Errors for DDSketch operations
+/// Errors returned by [`DDSketch`] operations.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum DDSketchError {
-    /// Alpha parameter must be in range (0, 1)
+    /// The relative-error parameter `alpha` was outside the open interval
+    /// `(0, 1)` or was non-finite.
     InvalidAlpha,
-    /// Quantile must be in range [0, 1]
+    /// A quantile argument was outside the closed interval `[0, 1]` or was
+    /// non-finite.
     InvalidQuantile,
-    /// Cannot merge sketches with different alpha values
+    /// Attempted to merge two sketches whose `alpha` (and therefore `gamma`)
+    /// values differ.
     AlphaMismatch,
-    /// Bin count exceeds maximum allowed
+    /// Bin count exceeds the sketch's configured maximum.
     BinCountMismatch,
 }
 
@@ -67,16 +73,32 @@ where
 
 /// A DDSketch quantile estimator with configurable relative accuracy.
 ///
-/// DDSketch provides fast quantile estimation with bounded relative error.
-/// It's fully mergeable and designed for high-throughput data collection.
+/// `DDSketch` provides fast quantile estimation with a bounded **relative**
+/// error `alpha`: any quantile estimate is within `alpha * q` of the true
+/// value `q`. It handles negative, zero, and positive values, is fully
+/// mergeable, and uses bounded memory.
+///
+/// # Example
+///
+/// ```
+/// use ddsketchy::DDSketch;
+///
+/// let mut sketch = DDSketch::new(0.01).expect("valid alpha");
+/// for v in 1..=100 {
+///     sketch.add(v as f64);
+/// }
+/// let p99 = sketch.quantile(0.99).unwrap();
+/// // Result is within 1% relative error of 99.
+/// assert!((p99 - 99.0).abs() < 99.0 * 0.01);
+/// ```
 ///
 /// # Serialization
 ///
 /// When the `serde` feature is enabled, `DDSketch` implements
-/// `Serialize` and `Deserialize`.
+/// `serde::Serialize` and `serde::Deserialize`:
 ///
 /// ```toml
-/// dd-sketchy = { features = ["serde"] }
+/// ddsketchy = { version = "*", features = ["serde"] }
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -118,7 +140,26 @@ pub struct DDSketch {
 }
 
 impl DDSketch {
-    /// Create a new DDSketch with relative error `alpha` (0 < alpha < 1)
+    /// Creates a new `DDSketch` with the given relative-error parameter.
+    ///
+    /// `alpha` must lie in the open interval `(0, 1)`. Smaller values give
+    /// tighter quantile estimates at the cost of more memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DDSketchError::InvalidAlpha`] if `alpha` is not finite or is
+    /// outside `(0, 1)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::{DDSketch, DDSketchError};
+    ///
+    /// let sketch = DDSketch::new(0.01).expect("valid alpha");
+    /// assert_eq!(sketch.count(), 0);
+    ///
+    /// assert_eq!(DDSketch::new(0.0).unwrap_err(), DDSketchError::InvalidAlpha);
+    /// ```
     pub fn new(alpha: f64) -> Result<Self, DDSketchError> {
         if !alpha.is_finite() || alpha <= 0.0 || alpha >= 1.0 {
             return Err(DDSketchError::InvalidAlpha);
@@ -153,29 +194,49 @@ impl DDSketch {
         })
     }
 
-    /// Map a value to a bin key
+    /// Maps a value to the internal bin key used by this sketch.
+    ///
+    /// This is a low-level accessor that is primarily useful for debugging or
+    /// for implementing custom stores.
     #[inline]
     pub fn key(&self, value: f64) -> i32 {
         crate::mapping::value_to_key_i32(value, self.inv_ln_gamma)
     }
 
-    /// Get the minimum indexable value (MinIndexableValue)
+    /// Returns the smallest positive magnitude this sketch can represent.
     ///
-    /// Values below this threshold are clamped to the zero bucket.
-    /// Matches DataDog's Mapping.MinIndexableValue() behavior.
+    /// Values with absolute value below this threshold are mapped to the zero
+    /// bucket. This matches DataDog's `Mapping.MinIndexableValue()` behaviour.
     #[inline]
     pub fn min_possible(&self) -> f64 {
         self.min_indexable_value
     }
 
-    /// Map a key back to its representative value
-    /// Uses exact Go/Java style implementation with upward bias
+    /// Maps a bin key back to a representative value.
+    ///
+    /// This is the inverse of [`DDSketch::key`] and is used internally when
+    /// reconstructing quantile estimates.
     #[inline]
     pub fn value(&self, key: i32) -> f64 {
         crate::mapping::key_to_value_i32(key, self.gamma, self.inv_ln_gamma.recip())
     }
 
-    /// Add a value to the sketch
+    /// Adds a single value to the sketch.
+    ///
+    /// Non-finite values (`NaN`, `±∞`) are silently ignored. Finite values
+    /// whose absolute magnitude is below [`DDSketch::min_possible`] are
+    /// counted in the zero bucket.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add(1.0);
+    /// sketch.add(2.0);
+    /// assert_eq!(sketch.count(), 2);
+    /// ```
     #[inline]
     pub fn add(&mut self, value: f64) {
         if !value.is_finite() {
@@ -201,7 +262,27 @@ impl DDSketch {
         }
     }
 
-    /// Merge another sketch into this one
+    /// Merges another sketch into this one.
+    ///
+    /// Both sketches must share the same `alpha` (relative-error) parameter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DDSketchError::AlphaMismatch`] if the two sketches were
+    /// constructed with different `alpha` values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut a = DDSketch::new(0.01).unwrap();
+    /// a.add(1.0);
+    /// let mut b = DDSketch::new(0.01).unwrap();
+    /// b.add(2.0);
+    /// a.merge(&b).unwrap();
+    /// assert_eq!(a.count(), 2);
+    /// ```
     pub fn merge(&mut self, other: &Self) -> Result<(), DDSketchError> {
         if (self.gamma - other.gamma).abs() > 1e-10 {
             return Err(DDSketchError::AlphaMismatch);
@@ -224,32 +305,75 @@ impl DDSketch {
         Ok(())
     }
 
-    /// Returns the number of values added to the sketch
+    /// Returns the total number of values that have been added to the sketch.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add(1.0);
+    /// sketch.add(2.0);
+    /// assert_eq!(sketch.count(), 2);
+    /// ```
     #[inline]
     pub fn count(&self) -> u64 {
         self.positive_store.count() + self.negative_store.count() + self.zero_count
     }
 
-    /// Returns the number of values added to the sketch (Rust collection convention)
+    /// Returns the total number of values in the sketch as a `usize`.
+    ///
+    /// This mirrors the Rust collection convention; see also [`count`].
+    ///
+    /// [`count`]: Self::count
     #[inline]
     pub fn len(&self) -> usize {
         self.count() as usize
     }
 
-    /// Returns true if the sketch is empty
+    /// Returns `true` if no values have been added to the sketch.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.count() == 0
     }
 
-    /// Returns the sum of all values added to the sketch
+    /// Returns the arithmetic sum of all values added to the sketch.
+    ///
+    /// Unlike the quantile estimates, the sum is tracked exactly (modulo
+    /// floating-point accumulation error).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add(1.0);
+    /// sketch.add(2.0);
+    /// sketch.add(3.0);
+    /// assert_eq!(sketch.sum(), 6.0);
+    /// ```
     #[inline]
     pub fn sum(&self) -> f64 {
         self.sum
     }
 
-    /// Returns the mean of all values added to the sketch
-    /// Returns 0.0 if the sketch is empty
+    /// Returns the mean of all values added to the sketch, or `0.0` if empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add(2.0);
+    /// sketch.add(4.0);
+    /// assert_eq!(sketch.mean(), 3.0);
+    ///
+    /// let empty = DDSketch::new(0.01).unwrap();
+    /// assert_eq!(empty.mean(), 0.0);
+    /// ```
     #[inline]
     pub fn mean(&self) -> f64 {
         if self.count() == 0 {
@@ -298,8 +422,22 @@ impl DDSketch {
         combined_bins
     }
 
-    /// Returns the minimum reconstructed value (equivalent to quantile(0.0))
-    /// This matches Go DDSketch behavior where min/max return reconstructed values
+    /// Returns the reconstructed minimum value, equivalent to `quantile(0.0)`.
+    ///
+    /// Returns `f64::INFINITY` when the sketch is empty (matching the Go
+    /// reference implementation).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add(1.0);
+    /// sketch.add(10.0);
+    /// // min is reconstructed and therefore only approximate.
+    /// assert!((sketch.min() - 1.0).abs() < 1.0 * 0.01);
+    /// ```
     #[inline]
     pub fn min(&self) -> f64 {
         if self.count() == 0 {
@@ -308,8 +446,20 @@ impl DDSketch {
         self.quantile(0.0).unwrap_or(f64::INFINITY)
     }
 
-    /// Returns the maximum reconstructed value (equivalent to quantile(1.0))
-    /// This matches Go DDSketch behavior where min/max return reconstructed values
+    /// Returns the reconstructed maximum value, equivalent to `quantile(1.0)`.
+    ///
+    /// Returns `f64::NEG_INFINITY` when the sketch is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add(1.0);
+    /// sketch.add(10.0);
+    /// assert!((sketch.max() - 10.0).abs() < 10.0 * 0.01);
+    /// ```
     #[inline]
     pub fn max(&self) -> f64 {
         if self.count() == 0 {
@@ -318,13 +468,15 @@ impl DDSketch {
         self.quantile(1.0).unwrap_or(f64::NEG_INFINITY)
     }
 
-    /// Returns the alpha (relative error) parameter used to create this sketch
+    /// Returns the `alpha` (relative-error) parameter this sketch was built with.
     #[inline]
     pub fn alpha(&self) -> f64 {
         (self.gamma - 1.0) / (self.gamma + 1.0)
     }
 
-    /// Clears all data from the sketch, resetting it to empty state
+    /// Resets the sketch to its empty state, discarding all accumulated data.
+    ///
+    /// The `alpha` configuration is preserved.
     pub fn clear(&mut self) {
         self.sum = 0.0;
         self.min = f64::INFINITY;
@@ -334,16 +486,33 @@ impl DDSketch {
         self.zero_count = 0;
     }
 
-    /// Returns the value at the given quantile
+    /// Returns the estimated value at quantile `q`.
     ///
-    /// # Arguments
-    /// * `q` - The quantile to query, must be in range [0.0, 1.0]
+    /// The returned value is within a multiplicative factor of `alpha` of the
+    /// true quantile (see [`DDSketch::alpha`]).
     ///
-    /// # Returns
-    /// * `Ok(value)` - The estimated value at the quantile
-    /// * `Err(DDSketchError::InvalidQuantile)` - If quantile is outside [0.0, 1.0]
+    /// `q` must be finite and in the closed interval `[0.0, 1.0]`. For an
+    /// empty sketch this method returns `Ok(0.0)` for backward compatibility;
+    /// use [`DDSketch::quantile_opt`] if you want to distinguish "empty" from
+    /// "zero".
     ///
-    /// Returns 0.0 if the sketch is empty for backward compatibility.
+    /// # Errors
+    ///
+    /// Returns [`DDSketchError::InvalidQuantile`] if `q` is non-finite or
+    /// outside `[0.0, 1.0]`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// for v in 1..=100 {
+    ///     sketch.add(v as f64);
+    /// }
+    /// let median = sketch.quantile(0.5).unwrap();
+    /// assert!((median - 50.0).abs() < 50.0 * 0.01 + 0.5);
+    /// ```
     pub fn quantile(&self, q: f64) -> Result<f64, DDSketchError> {
         if !(0.0..=1.0).contains(&q) {
             return Err(DDSketchError::InvalidQuantile);
@@ -384,7 +553,13 @@ impl DDSketch {
         }
     }
 
-    /// Returns the value at the given quantile, with Option for empty handling
+    /// Like [`quantile`](Self::quantile), but returns `Ok(None)` when the
+    /// sketch is empty rather than `Ok(0.0)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DDSketchError::InvalidQuantile`] if `q` is non-finite or
+    /// outside `[0.0, 1.0]`.
     pub fn quantile_opt(&self, q: f64) -> Result<Option<f64>, DDSketchError> {
         if !(0.0..=1.0).contains(&q) {
             return Err(DDSketchError::InvalidQuantile);
@@ -396,29 +571,50 @@ impl DDSketch {
         Ok(Some(self.quantile(q)?))
     }
 
-    /// Debug method to get positive store count
+    /// Returns the number of values stored in the positive store.
+    ///
+    /// Primarily useful for debugging and introspection.
     pub fn positive_store_count(&self) -> u64 {
         self.positive_store.count()
     }
 
-    /// Debug method to get zero count
+    /// Returns the number of values counted in the zero bucket.
+    ///
+    /// Primarily useful for debugging and introspection.
     pub fn get_zero_count(&self) -> u64 {
         self.zero_count
     }
 
-    /// Debug method to get negative store count
+    /// Returns the number of values stored in the negative store.
+    ///
+    /// Primarily useful for debugging and introspection.
     pub fn negative_store_count(&self) -> u64 {
         self.negative_store.count()
     }
 
-    /// Debug method to get key at rank from positive store
+    /// Returns the bin key at the given rank within the positive store.
+    ///
+    /// Primarily useful for debugging and introspection.
     pub fn positive_key_at_rank(&self, rank: u64) -> i32 {
         self.positive_store.key_at_rank(rank)
     }
 
-    /// Returns commonly used percentiles (P50, P90, P95, P99)
+    /// Returns the commonly used percentiles `(P50, P90, P95, P99)`.
     ///
-    /// Returns None if the sketch is empty.
+    /// Returns `None` if the sketch is empty.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// for v in 1..=100 {
+    ///     sketch.add(v as f64);
+    /// }
+    /// let (p50, p90, p95, p99) = sketch.percentiles().unwrap();
+    /// assert!(p50 < p90 && p90 < p95 && p95 < p99);
+    /// ```
     pub fn percentiles(&self) -> Option<(f64, f64, f64, f64)> {
         if self.count() == 0 {
             return None;
@@ -432,7 +628,20 @@ impl DDSketch {
         ))
     }
 
-    /// Add multiple values efficiently with reduced overhead
+    /// Adds every value produced by `values` to the sketch.
+    ///
+    /// Equivalent to calling [`add`](Self::add) in a loop but communicates
+    /// intent and allows future batched optimizations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ddsketchy::DDSketch;
+    ///
+    /// let mut sketch = DDSketch::new(0.01).unwrap();
+    /// sketch.add_batch([1.0, 2.0, 3.0]);
+    /// assert_eq!(sketch.count(), 3);
+    /// ```
     #[inline]
     pub fn add_batch<I>(&mut self, values: I)
     where
@@ -488,14 +697,25 @@ impl Extend<f64> for DDSketch {
     }
 }
 
-// Builder pattern for flexible construction
+/// Builder for configuring and constructing a [`DDSketch`].
+///
+/// Use [`DDSketch::builder`] to obtain a new builder.
+///
+/// # Example
+///
+/// ```
+/// use ddsketchy::DDSketch;
+///
+/// let sketch = DDSketch::builder(0.01).max_bins(2048).build().unwrap();
+/// assert_eq!(sketch.count(), 0);
+/// ```
 pub struct DDSketchBuilder {
     alpha: f64,
     max_bins: Option<usize>,
 }
 
 impl DDSketchBuilder {
-    /// Create a new builder with the specified alpha
+    /// Creates a new builder with the given relative-error parameter.
     pub fn new(alpha: f64) -> Self {
         Self {
             alpha,
@@ -503,13 +723,21 @@ impl DDSketchBuilder {
         }
     }
 
-    /// Set the maximum number of bins (default: 4096)
+    /// Sets the maximum number of bins in each (positive / negative) store.
+    ///
+    /// The default is `4096`. Larger values allow the sketch to cover a wider
+    /// dynamic range before collapsing bins.
     pub fn max_bins(mut self, max_bins: usize) -> Self {
         self.max_bins = Some(max_bins);
         self
     }
 
-    /// Build the DDSketch
+    /// Finalizes the builder and returns the configured [`DDSketch`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DDSketchError::InvalidAlpha`] if `alpha` is not finite or is
+    /// outside `(0, 1)`.
     pub fn build(self) -> Result<DDSketch, DDSketchError> {
         if !self.alpha.is_finite() || self.alpha <= 0.0 || self.alpha >= 1.0 {
             return Err(DDSketchError::InvalidAlpha);
@@ -549,12 +777,19 @@ impl DDSketchBuilder {
 }
 
 impl DDSketch {
-    /// Create a new builder for constructing a DDSketch
+    /// Returns a [`DDSketchBuilder`] for constructing a sketch with extra
+    /// configuration beyond the default [`DDSketch::new`] options.
     pub fn builder(alpha: f64) -> DDSketchBuilder {
         DDSketchBuilder::new(alpha)
     }
 
-    /// Create a DDSketch with custom maximum bins
+    /// Convenience constructor: builds a `DDSketch` with the given `alpha`
+    /// and a custom `max_bins`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DDSketchError::InvalidAlpha`] if `alpha` is not finite or is
+    /// outside `(0, 1)`.
     pub fn with_max_bins(alpha: f64, max_bins: usize) -> Result<Self, DDSketchError> {
         Self::builder(alpha).max_bins(max_bins).build()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,45 @@
 #![forbid(unsafe_code)]
+//! # ddsketchy
+//!
+//! A Rust implementation of the [DDSketch] quantile sketch algorithm.
+//!
+//! DDSketch is a fast, fully-mergeable quantile sketch with **relative-error
+//! guarantees**: every quantile estimate is within a user-chosen multiplicative
+//! factor `alpha` of the true value. This makes it well-suited to latency
+//! distributions and other data that spans many orders of magnitude, where
+//! absolute-error sketches behave poorly. Sketches are cheap to merge, making
+//! them a natural fit for distributed aggregation.
+//!
+//! [DDSketch]: https://arxiv.org/pdf/1908.10693.pdf
+//!
+//! # Quick start
+//!
+//! ```
+//! use ddsketchy::DDSketch;
+//!
+//! let mut sketch = DDSketch::new(0.01).expect("valid alpha");
+//! for v in [1.0, 2.0, 3.0, 4.0, 5.0] {
+//!     sketch.add(v);
+//! }
+//!
+//! // Quantiles are accurate to within `alpha` (1%) relative error.
+//! let median = sketch.quantile(0.5).unwrap();
+//! assert!((median - 3.0).abs() < 3.0 * 0.01 + 0.05);
+//! assert_eq!(sketch.count(), 5);
+//! ```
+//!
+//! # Features
+//!
+//! - `serde` — enables `Serialize` / `Deserialize` for [`DDSketch`].
+//! - `python` — enables PyO3 bindings (used by the Python wheel build).
+//!
+//! # More examples
+//!
+//! See the [`examples/`] directory in the repository for runnable examples,
+//! including serialization round-trips and the code snippets shown in the
+//! README.
+//!
+//! [`examples/`]: https://github.com/pmcgleenon/ddsketchy/tree/main/examples
 
 mod ddsketchy;
 mod mapping;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! // Quantiles are accurate to within `alpha` (1%) relative error.
 //! let median = sketch.quantile(0.5).unwrap();
-//! assert!((median - 3.0).abs() < 3.0 * 0.01 + 0.05);
+//! assert!((median - 3.0).abs() <= 3.0 * 0.01);
 //! assert_eq!(sketch.count(), 5);
 //! ```
 //!

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,7 +1,16 @@
+//! Python bindings for [`DDSketch`](crate::DDSketch) via PyO3.
+//!
+//! These bindings are only compiled when the `python` feature is enabled.
+//! The exposed Python class is named `DDSketch` (see the `ddsketchy`
+//! pymodule).
+
 use crate::ddsketchy::{DDSketch as DDSketchInner, DDSketchError};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+/// Python-facing wrapper around [`crate::DDSketch`].
+///
+/// Constructed from Python as `DDSketch(alpha=0.01)`.
 #[pyclass]
 pub struct DDSketch {
     inner: DDSketchInner,
@@ -15,6 +24,9 @@ impl From<DDSketchError> for PyErr {
 
 #[pymethods]
 impl DDSketch {
+    /// Creates a new sketch with the given relative-error `alpha`.
+    ///
+    /// Raises `ValueError` if `alpha` is outside `(0, 1)`.
     #[new]
     #[pyo3(signature = (alpha=0.01))]
     fn new(alpha: f64) -> PyResult<Self> {
@@ -22,60 +34,77 @@ impl DDSketch {
         Ok(Self { inner })
     }
 
+    /// Adds a single value to the sketch.
     fn add(&mut self, value: f64) {
         self.inner.add(value);
     }
 
+    /// Adds every value in the provided sequence to the sketch.
     fn add_batch(&mut self, values: Vec<f64>) {
         self.inner.add_batch(values);
     }
 
+    /// Returns the estimated value at quantile `q`, where `q` is in `[0, 1]`.
+    ///
+    /// Raises `ValueError` if `q` is outside `[0, 1]`.
     fn quantile(&self, q: f64) -> PyResult<f64> {
         self.inner.quantile(q).map_err(PyErr::from)
     }
 
+    /// Merges another sketch into this one in place.
+    ///
+    /// Raises `ValueError` if the two sketches use different `alpha` values.
     fn merge(&mut self, other: &DDSketch) -> PyResult<()> {
         self.inner.merge(&other.inner).map_err(PyErr::from)
     }
 
+    /// Number of values added to the sketch.
     #[getter]
     fn count(&self) -> u64 {
         self.inner.count()
     }
 
+    /// Sum of all values added to the sketch.
     #[getter]
     fn sum(&self) -> f64 {
         self.inner.sum()
     }
 
+    /// Arithmetic mean of all values, or `0.0` when empty.
     #[getter]
     fn mean(&self) -> f64 {
         self.inner.mean()
     }
 
+    /// Reconstructed minimum value, or `+inf` when empty.
     #[getter]
     fn min(&self) -> f64 {
         self.inner.min()
     }
 
+    /// Reconstructed maximum value, or `-inf` when empty.
     #[getter]
     fn max(&self) -> f64 {
         self.inner.max()
     }
 
+    /// The `alpha` relative-error parameter the sketch was built with.
     #[getter]
     fn alpha(&self) -> f64 {
         self.inner.alpha()
     }
 
+    /// Returns `True` if no values have been added.
     fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
+    /// Clears all accumulated data, preserving the `alpha` configuration.
     fn clear(&mut self) {
         self.inner.clear();
     }
 
+    /// Returns `(P50, P90, P95, P99)`, or `None` if the sketch is empty.
     fn percentiles(&self) -> Option<(f64, f64, f64, f64)> {
         self.inner.percentiles()
     }
@@ -93,6 +122,7 @@ impl DDSketch {
     }
 }
 
+/// The `ddsketchy` Python module entry point.
 #[pymodule]
 fn ddsketchy(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DDSketch>()?;


### PR DESCRIPTION
## Summary
- Add crate-level rustdoc overview in `src/lib.rs` with quick-start doctest
- Add 13 doctests on `DDSketch` methods in `src/ddsketchy.rs`; expand method docs
- Add PyO3 docstrings in `src/python.rs`
- Enforce rustdoc warnings in CI via `RUSTDOCFLAGS: \"-D warnings\"` on the docs job
- Build examples with `--features serde` so serde-gated examples compile in CI

## Test plan
- [x] `cargo test --doc --features serde` — 14 passed
- [x] `cargo doc --no-deps --features serde` — clean
- [ ] CI docs job passes with `-D warnings`

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)